### PR TITLE
Fix cycling dependencies in 'catkin_make'

### DIFF
--- a/yolact_ros_octomap_mapping/CMakeLists.txt
+++ b/yolact_ros_octomap_mapping/CMakeLists.txt
@@ -90,7 +90,7 @@ add_library(${PROJECT_NAME} ${SRCS})
 add_definitions(-std=c++11)
 
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS})
-add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_generate_messages_cpp)
 
 add_executable(octomap_server_node src/octomap_server/octomap_server_node.cpp)
 target_link_libraries(octomap_server_node ${PROJECT_NAME} ${LINK_LIBS})


### PR DESCRIPTION
Fix the cycling dependencies in `CMakeLists.txt` to avoid compilation order errors when executing `catkin_make`.